### PR TITLE
Overhaul opentdb.py to comply with API limits and filter invalid questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,23 @@
 
 ![Screenshot](screenshot.png)
 
-Tool for inserting custom questions/answers into the Quiz and Dragons MAME rom (qad.zip). Built using the OpenTDB API,
+Tool for inserting custom questions/answers into the Quiz & Dragons MAME rom (qad.zip). Built using the OpenTDB API,
 but questions can be added from any source.
 
 For detailed info on how QaD stores and interprets questions, see [Notes](notes.md).
 
-Requires Python3 and [unidecode](https://pypi.org/project/Unidecode/).
+Requires Python3, [Requests](https://docs.python-requests.org/en/latest/index.html), and [Unidecode](https://pypi.org/project/Unidecode/).
 
 ## Installation
 
 1. Move a clean copy of qad.zip to the clean_rom directory
-2. (Optional) Modify `SELECTED_CATEGORY_IDS` in opentdb.py to the categories you want to include. Max 14 categories.
-3. Run `pip3 install Unidecode`
+2. (Optional) Open opentdb.py and configure the options at the top of the file. `SELECTED_CATEGORY_IDS` should include a maximum of 14 categories.
+3. Run `pip3 install requests Unidecode`
 4. Run `./opentdb.py`
-5. Run `./build.py`
-6. Move `patched/qad.zip` to your MAME roms directory and run mame from command line to skip CRC
+5. (Optional) Review `questions_error.json` for questions that contain characters not supported by Quiz & Dragons,
+   and manually correct and insert them into questions.json
+6. Run `./build.py`
+7. Move `patched/qad.zip` to your MAME roms directory and run mame from command line to skip CRC
    checks (`./mame.exe qad`)
 
 ## Using a question source besides OpenTDB
@@ -25,3 +27,14 @@ This is simple enough, just write your questions to `questions.json` in the same
 sample file called `questions_sample.json` for reference. The first answer is the correct one. Make sure you're aware of
 the limits described in the "Questions/Answers" section of [Notes](notes.md). Once questions.json exists and is filled
 with trivia, run `build.py`.
+
+## Notes on OpenTDB API Limits
+
+The OpenTDB API has a limit of 50 questions per request and 1 request per IP every 5 seconds. The `opentdb.py` script will
+pause every 6 seconds (by default) to attempt to respect the rate limits.
+
+Additionally, while the total number of questions in a given category and difficulty can be queried, the API will report
+the total number of questions including true/false questions, which Quiz & Dragons does not support. To maximize the number
+of questions this script can retrieve, it will download all available questions and then filter out true/false questions, at
+the expense of extra API requests that can potentially return 0 useful questions. As a result of this, the number of
+questions added to questions.json by the script will be lower than the total reported by the API.

--- a/build.py
+++ b/build.py
@@ -38,8 +38,12 @@ def build_rom():
     logger.setLevel(logging.INFO)
     sh = logging.StreamHandler()
     logger.addHandler(sh)
-    if not check_zip_hash(CLEAN_ROM_DIR, ZIP_FILENAME):
-        logger.error("qad.zip file hash does not match. Make sure you're using the most recent version of qad.zip")
+    try:
+        if not check_zip_hash(CLEAN_ROM_DIR, ZIP_FILENAME):
+            logger.error("qad.zip file hash does not match. Make sure you're using the most recent version of qad.zip")
+            sys.exit(1)
+    except FileNotFoundError:
+        logger.error("qad.zip not found in clean_rom directory.")
         sys.exit(1)
     logger.info("Extracting, deinterleaving, and combining ROM files")
     extract_zip(CLEAN_ROM_DIR, ZIP_FILENAME)

--- a/opentdb.py
+++ b/opentdb.py
@@ -1,10 +1,12 @@
-#!/usr/bin/env python3 
+#!/usr/bin/env python3
 import requests
 import sys
+import time
 import re
 from unidecode import unidecode
 import json
 from urllib.parse import unquote
+from typing import List
 
 # Grab a ton of questions from openTDB
 '''
@@ -34,7 +36,68 @@ Categories by ID:
 31 - Entertainment: Japanese Anime & Manga
 32 - Entertainment: Cartoon & Animations
 '''
-SELECTED_CATEGORY_IDS = [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 23, 23, 27]
+SELECTED_CATEGORY_IDS = [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 23, 27]
+
+# Request this many questions at a time. This can be set to a lower
+# amount to reduce the chances that newer questions will be excluded,
+# as the API will not return any questions if there are fewer questions
+# left in a category than this amount, but the exact amount is not
+# reliable. As a workaround, the script will retry twice if the API
+# reports that all available questions have been exhausted before the
+# amount reported was downloaded, with 1 fewer question each time.
+# The OpenTDB API allows downloading up to 50 questions per request.
+QUESTION_REQUEST_AMOUNT = 50
+
+# The OpenTDB API limits requests to 1 per IP every 5 seconds.
+# Set this delay (in seconds) longer if you get frequent API rate limit
+# errors.
+API_REQUEST_INTERVAL = 6
+
+# Some questions in the OpenTDB dataset have accented letters and other
+# characters that are not supported in the Quiz & Dragons font.
+# Unidecode can process accented letters into unaccented letters, but
+# this can cause some correct answers to appear incorrect, or vice
+# versa.
+# If these settings are True, these questions will be written to
+# a file named questions_error.json to allow the user to correct them
+# manually before inserting them into questions.json. This script does
+# not validate the length of these strings, so any questions or answers
+# that exceed the limits in Quiz & Dragons will still be rejected by
+# build.py.
+# PRINT_INVALID_QUESTIONS can be set to True if you want to see
+# questions that get filtered during the download process.
+FILTER_INVALID_CHARACTERS_IN_QUESTIONS = False
+FILTER_INVALID_CHARACTERS_IN_ANSWERS = True
+PRINT_INVALID_QUESTIONS = False
+
+### No more configurable options after this point.
+
+
+def check_text(text: str | List[str]) -> str:
+    """Check the strings in the argument for invalid characters, which
+    can be a string (a question) or a list of strings (answers).
+    If no errors are found, returns an empty string. Otherwise, returns
+    a string that contains the text with invalid characters.
+    """
+
+    allowed_characters = re.compile('^[ !"$%&\'()+,-./0-9:;<=>?A-Z_a-z\{\}“”ʻ’…÷*~]*$')
+
+    if isinstance(text,str):
+        if allowed_characters.fullmatch(text) is None:
+            return f"Question {text} contains invalid characters"
+
+    elif isinstance(text,list):
+        errors = []
+        for a in text:
+            if allowed_characters.fullmatch(a) is None:
+                errors.append(a)
+        if len(errors) == 1:
+            return f"Answer {errors[0]} contains invalid characters"
+        elif len(errors) > 1:
+            return f"Answers {errors} contain invalid characters"
+
+    return ""
+
 
 def fix_str(s, question=False):
     """ Remove/replace non-ascii chars """
@@ -62,47 +125,148 @@ def fix_str(s, question=False):
 
 def main():
     print("Downloading questions")
-    r = requests.get("https://opentdb.com/api_token.php?command=request")
+    try:
+        r = requests.get("https://opentdb.com/api_token.php?command=request")
+    except requests.ConnectionError as e:
+        print("Cannot connect to OpenTDB API. Wait a few moments and try again.")
+        exit(1)
     session_token = r.json()["token"]
 
     questions = []
+    questions_error = []
     for id in SELECTED_CATEGORY_IDS:
-        for difficulty in ["medium", "easy"]:
+
+        # Get total number of questions in easy and medium difficulties.
+        url = f"https://opentdb.com/api_count.php?category={id}"
+        while True:
+            try:
+                r = requests.get(url)
+                j = r.json()
+                print(f"\nDownloading category ID {j['category_id']}.")
+                easy_questions = j["category_question_count"]["total_easy_question_count"]
+                medium_questions = j["category_question_count"]["total_medium_question_count"]
+                print(f"{str(easy_questions)} easy questions and {str(medium_questions)} medium questions in this category.")
+                time.sleep(API_REQUEST_INTERVAL)
+            except requests.ConnectionError as e:
+                print(e)
+                print("Cannot connect to OpenTDB API. Retrying in 5 seconds.")
+                time.sleep(5)
+                continue
+            break
+
+        for difficulty in ["easy","medium"]:
+            if difficulty == "easy":
+                remaining_questions = easy_questions
+            elif difficulty == "medium":
+                remaining_questions = medium_questions
+
+            # The total number of questions per difficulty reported by the
+            # API is not always accurate. When response code 4 is returned,
+            # try one more time with 1 fewer question up to twice before
+            # continuing with the next difficulty.
+            retries = 2
+
             while True:
+                if remaining_questions == 0:
+                    break
+                if remaining_questions >= QUESTION_REQUEST_AMOUNT:
+                    next_questions = QUESTION_REQUEST_AMOUNT
+                else:
+                    next_questions = remaining_questions
+
                 params = {
                     "token": session_token,
                     "category": id,
                     "difficulty": difficulty,
-                    "amount": 50,
+                    "amount": next_questions,
                     "encode": "url3986",
-                    "type": "multiple"
+                    # "type": "multiple"
                 }
                 url = "https://opentdb.com/api.php"
-                r = requests.get(url, params=params)
+                try:
+                    r = requests.get(url, params=params)
+                except requests.ConnectionError as e:
+                    print(e)
+                    print("Cannot connect to OpenTDB API. Retrying in 5 seconds.")
+                    time.sleep(5)
+                    continue
+
                 j = r.json()
                 if j["response_code"] in [1, 2, 3]:
                     sys.exit("Error from OpenTDB: %s" % j["response_message"])
                 elif j["response_code"] == 4:
-                    break
+                    time.sleep(API_REQUEST_INTERVAL)
+                    if retries > 0 and remaining_questions > retries:
+                        retries -= 1
+                        remaining_questions -= 1
+                        continue
+                    else:
+                        break
+
+                # If a rate limit is reached, wait 5 seconds before the next request.
+                elif j["response_code"] == 5:
+                    print("API rate limit reached. Waiting 5 seconds.")
+                    time.sleep(5)
+                    continue
+
                 for question in j["results"]:
+                    if question["type"] != "multiple":
+                        continue
+
+                    error = ""
                     category = unquote(question["category"])
                     # Category needs to be short
                     category = category.split(":")[-1].strip()
-                    text = fix_str(unquote(question["question"].strip()), question=True)
-                    answers = [fix_str(unquote(question["correct_answer"]))]
-                    for a in question["incorrect_answers"]:
-                        answers.append(fix_str(unquote(a)))
-                    question_dict = {
-                        "category": category,
-                        "question": text,
-                        "answers": answers
-                    }
-                    questions.append(question_dict)
+                    text = unquote(question["question"].strip())
+                    if FILTER_INVALID_CHARACTERS_IN_QUESTIONS:
+                        error = check_text(text)
+                        if error != "" and PRINT_INVALID_QUESTIONS:
+                            print(f"Warning: In category {category}, question '{text}' has invalid characters.")
+                    else:
+                        text = fix_str(text,question=True)
+
+                    answers = [unquote(question["correct_answer"].strip())] + [unquote(i.strip()) for i in question["incorrect_answers"]]
+                    if FILTER_INVALID_CHARACTERS_IN_ANSWERS:
+                        error = check_text(answers)
+                        if error != "" and PRINT_INVALID_QUESTIONS:
+                            print(f"Warning: In category {category}, question '{text}' has answers with invalid characters.\nAnswers: {answers}")
+                    else:
+                        answers = [fix_str(i) for i in answers]
+
+                    if error == "":
+                        question_dict = {
+                            "category": category,
+                            "question": text,
+                            "answers": answers
+                        }
+                    else:
+                        question_dict = {
+                            "category": category,
+                            "question": text,
+                            "answers": answers,
+                            "error" : error
+                        }
+
+                    if error == "":
+                        questions.append(question_dict)
+                    else:
+                        questions_error.append(question_dict)
+
+                print(f"{len(questions)} questions added.")
+                remaining_questions -= next_questions
+                time.sleep(API_REQUEST_INTERVAL)
 
     with open("questions.json", "w") as f:
         questions_sorted = sorted(questions, key=lambda q: q['category'])
         json.dump(questions_sorted, f, indent=4)
-    print(f"Wrote {len(questions)} to {'questions.json'}")
+    if questions_error:
+        with open("questions_error.json", "w", encoding="utf8") as f:
+            questions_sorted = sorted(questions_error, key=lambda q: q['category'])
+            json.dump(questions_sorted, f, ensure_ascii=False, indent=4)
+
+    print(f"\nWrote {len(questions)} questions to questions.json.")
+    print(f"Wrote {len(questions_error)} questions with errors to questions_error.json. You can review these questions, manually correct them, and insert them into questions.json.")
+
 
 if __name__ == "__main__":
     main()

--- a/opentdb.py
+++ b/opentdb.py
@@ -214,6 +214,7 @@ def main():
                         continue
 
                     error = ""
+                    error2 = ""
                     category = unquote(question["category"])
                     # Category needs to be short
                     category = category.split(":")[-1].strip()
@@ -227,9 +228,13 @@ def main():
 
                     answers = [unquote(question["correct_answer"].strip())] + [unquote(i.strip()) for i in question["incorrect_answers"]]
                     if FILTER_INVALID_CHARACTERS_IN_ANSWERS:
-                        error = check_text(answers)
-                        if error != "" and PRINT_INVALID_QUESTIONS:
+                        error2 = check_text(answers)
+                        if error2 != "" and PRINT_INVALID_QUESTIONS:
                             print(f"Warning: In category {category}, question '{text}' has answers with invalid characters.\nAnswers: {answers}")
+                            if error != "":
+                                error += "\n" + error2
+                            else:
+                                error = error2
                     else:
                         answers = [fix_str(i) for i in answers]
 


### PR DESCRIPTION
As of 2023, the OpenTDB API has rate limits that the current version of this script does not account for. The script also does not attempt to validate question text that contains accented letters. Unidecode can map these letters to unaccented letters, but this results in some correct answers becoming incorrect and vice versa, or in the worst case, the correct answer having identical text with an incorrect answer. An example with text processed by Unidecode:
```json
    {
        "category": "General Knowledge",
        "question": "What is the Portuguese word for {Brazil }?",
        "answers": [
            "Brasil",
            "Brazil",
            "Brasilia",
            "Brasil"
        ]
    }
```
The API also only reports the total number of questions in a category and does not separate them by the type of question. The current version of the script requests only multiple choice questions, and when the API runs out of multiple choice questions to return, it will report no more questions are available even when there are, because true/false questions are not accounted for in the request.

This pull request corrects these issues by doing the following:

- Download the maximum of 50 questions at a time, with a default 6 second delay between requests
- Filter questions that have answers with characters not in the Quiz & Dragons ROM, and write all such questions into a file named questions_error.json. These questions can be manually reviewed and rewritten by the user, before manually inserting them into questions.json.
- Download all questions, not just multiple choice questions, and then filter non-multiple choice questions
- If the API reports no more questions are available before the reported total number of questions have been downloaded, retry up to twice with 1 fewer question in the request

This pull request also adds a basic check in build.py if qad.zip exists in the clean_rom directory.