### PR TITLE
Category name + Italics bugfixes

### DIFF
--- a/QADPatch/QuizQuestions.py
+++ b/QADPatch/QuizQuestions.py
@@ -101,6 +101,18 @@ class QuestionList:
                 categories.append(q.category)
 
         return len(categories)
+    
+    def category_names_size(self):
+        """ 
+        Returns the amount of bytes required to store all category names. Used for
+        validation.
+        """
+        categories = []
+        for q in self.question_list:
+            if q.category not in categories:
+                categories.append(q.category)
+
+        return sum(len(category)+1 for category in categories)
 
     def calculate_word_frequency(self):
         """ Given a list of QuizQuestions, return an ordered frequency dict ({"word": <usage count>}) """

--- a/opentdb.py
+++ b/opentdb.py
@@ -36,7 +36,12 @@ Categories by ID:
 31 - Entertainment: Japanese Anime & Manga
 32 - Entertainment: Cartoon & Animations
 '''
-SELECTED_CATEGORY_IDS = [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 23, 27]
+SELECTED_CATEGORY_IDS = [9, 10, 11, 12, 14, 15, 16, 17, 18, 20, 22, 23, 27]
+SHORTENED_CATEGORIES = {
+    "General Knowledge": "General",
+    "Science & Nature": "Science",
+    "Television": "TV"
+}
 
 # Request this many questions at a time. This can be set to a lower
 # amount to reduce the chances that newer questions will be excluded,
@@ -112,12 +117,12 @@ def fix_str(s, question=False):
                 index = s.index('"')
                 s = s[0:index] + "{" + s[index+1:]
                 index = s.index('"')
-                s = s[0:index] + " }" + s[index + 1:]
+                s = s[0:index] + "}" + s[index + 1:]
             elif len(ticks) >= 2:
                 index = s.index('`')
                 s = s[0:index] + "{" + s[index+1:]
                 index = s.index('`')
-                s = s[0:index] + " }" + s[index + 1:]
+                s = s[0:index] + "}" + s[index + 1:]
             else:
                 break
     return s
@@ -218,6 +223,9 @@ def main():
                     category = unquote(question["category"])
                     # Category needs to be short
                     category = category.split(":")[-1].strip()
+                    # For some categories, shorten them even more
+                    if category in SHORTENED_CATEGORIES:
+                        category = SHORTENED_CATEGORIES[category]
                     text = unquote(question["question"].strip())
                     if FILTER_INVALID_CHARACTERS_IN_QUESTIONS:
                         error = check_text(text)

--- a/util.py
+++ b/util.py
@@ -62,7 +62,6 @@ def build_zip():
 
     # Copy uncompressed raw files to output dir too in order to make IPS patches
     for fn in [ROM1A, ROM1B, ROM2A, ROM2B]:
-        print("copy ")
         shutil.copyfile(join(WORKING_DIR, fn), join(OUTPUT_DIR, fn))
 
     if os.path.isdir(WORKING_DIR):


### PR DESCRIPTION
There is a hard limit on the combined size of each category name, which previously was being overrun using the default settings in opentdb.py.

This change...

1. Adds a check in build.py which will fail if the combined category name size it too large.
2. Shortens some category names in opentdb.py to save some space.
3. Removes the musicals & theatre category as it had very few questions but a long name. 

Additionally it fixes an issue where curly braces around italics were incorrectly adding an extra space, breaking some questions. 